### PR TITLE
Enhancement/compact docker image

### DIFF
--- a/3.6/Dockerfile
+++ b/3.6/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.6-slim
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        wget=1.20.1-1.1 \
+        unzip=6.0-23+deb10u1 \
+        nodejs=10.21.0~dfsg-1~deb10u1 \
+        npm=5.8.0+ds6-4+deb10u1 && \
+    pip3 install --upgrade pip==20.1.1 && \
+    npm install npm@latest -g && \
+    npm install -g serverless && \
+    apt-get -q -y clean && \
+    rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+
+WORKDIR /work
+
+ENTRYPOINT ["/bin/sh"]

--- a/3.7/Dockerfile
+++ b/3.7/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.7-slim
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        wget=1.20.1-1.1 \
+        unzip=6.0-23+deb10u1 \
+        nodejs=10.21.0~dfsg-1~deb10u1 \
+        npm=5.8.0+ds6-4+deb10u1 && \
+    pip3 install --upgrade pip==20.1.1 && \
+    npm install npm@latest -g && \
+    npm install -g serverless && \
+    apt-get -q -y clean && \
+    rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+
+WORKDIR /work
+
+ENTRYPOINT ["/bin/sh"]

--- a/3.8/Dockerfile
+++ b/3.8/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.8-slim
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        wget=1.20.1-1.1 \
+        unzip=6.0-23+deb10u1 \
+        nodejs=10.21.0~dfsg-1~deb10u1 \
+        npm=5.8.0+ds6-4+deb10u1 && \
+    pip3 install --upgrade pip==20.1.1 && \
+    npm install npm@latest -g && \
+    npm install -g serverless && \
+    apt-get -q -y clean && \
+    rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
+
+WORKDIR /work
+
+ENTRYPOINT ["/bin/sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
-ARG base_image
-
-FROM ${base_image}
-
-RUN apt-get update && \
-    apt-get install -y wget unzip nodejs npm && \
-    npm install -g serverless
+FROM python:3.8-slim
 
 ADD requirements.txt /root/
-RUN pip3 install -r /root/requirements.txt
 
-RUN rm -rf /root/requirements.txt
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        wget=1.20.1-1.1 \
+        unzip=6.0-23+deb10u1 \
+        nodejs=10.21.0~dfsg-1~deb10u1 \
+        npm=5.8.0+ds6-4+deb10u1 && \
+    pip3 install --upgrade pip==20.1.1 && \
+    npm install npm@latest -g && \
+    npm install -g serverless && \
+    apt-get -q -y clean && \
+    rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 
 WORKDIR /work
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+DOCKER_REPO=dnxsolutions/serverless-python
+DOCKER_TAG=dnx2
+IMAGE_NAME=${DOCKER_REPO}:${DOCKER_TAG}
+
+build:
+	echo "Build specific tag/release"
+
+	# Python 3.6
+	docker build \
+		--build-arg base_image=python:3.6-slim \
+		-t ${DOCKER_REPO}:3.6-${DOCKER_TAG} \
+		.
+
+	# Python 3.7
+	docker build \
+		--build-arg base_image=python:3.7-slim \
+		-t ${DOCKER_REPO}:3.7-${DOCKER_TAG} \
+		.
+
+	# Python 3.8
+	docker build \
+		--build-arg base_image=python:3.8-slim \
+		-t ${DOCKER_REPO}:3.8-${DOCKER_TAG} \
+		.

--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,16 @@ build:
 	docker build \
 		--build-arg base_image=python:3.6-slim \
 		-t ${DOCKER_REPO}:3.6-${DOCKER_TAG} \
-		.
+		./3.6/.
 
 	# Python 3.7
 	docker build \
 		--build-arg base_image=python:3.7-slim \
 		-t ${DOCKER_REPO}:3.7-${DOCKER_TAG} \
-		.
+		./3.7/.
 
 	# Python 3.8
 	docker build \
 		--build-arg base_image=python:3.8-slim \
 		-t ${DOCKER_REPO}:3.8-${DOCKER_TAG} \
-		.
+		./3.8/.

--- a/test/build-images.sh
+++ b/test/build-images.sh
@@ -2,7 +2,7 @@
 set -ex
 
 DOCKER_REPO=dnxsolutions/serverless-python
-DOCKER_TAG=dnx1.0
+DOCKER_TAG=dnx2
 IMAGE_NAME=${DOCKER_REPO}:${DOCKER_TAG}
 
 if [ ${DOCKER_TAG} != "latest" ]


### PR DESCRIPTION
The main proposal change in this MR is that instead of keeping an `ARG` at the beginning of the `Dockerfile` I have created 3 folders with 3 `Dockerfiles` each pointing to one python version, `python:3.6-slim`, `python:3.7-slim`, `python:3.8-slim`. 

I also locked the dependencies from the images to increase stabillity and remove cache to compress it.
```bash
apt-get -q -y clean && \
rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
```

This compressed the image size from `242.37 MB` to `171.44 MB`

To finish up, I did some changes to Docker Hub building rules to support this new architecture.

#### Build rules now

![image](https://user-images.githubusercontent.com/18387694/84699030-32dab200-af27-11ea-964d-be8d0bc10450.png)

